### PR TITLE
Run release workflow on tag push

### DIFF
--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -1,7 +1,7 @@
 name: Build
 
 on:
-  create:
+  push:
     tags:
       - 'v*'
 


### PR DESCRIPTION
This patch triggers workflow on tag push only.