### PR TITLE
Build artifacts for python 3.11 and 3.12

### DIFF
--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -10,7 +10,7 @@ jobs:
   tests:
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -10,7 +10,7 @@ jobs:
   tests:
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.8', '3.9', '3.10', '3.11']
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -10,7 +10,7 @@ jobs:
   tests:
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -9,8 +9,8 @@ jobs:
   build_wheels:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
-        cibw_arch: ['x86_64']
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        cibw_arch: ['auto64']
 
     runs-on: ${{ matrix.os }}
 
@@ -20,12 +20,12 @@ jobs:
       - uses: actions/setup-python@v2
 
       - name: Install cibuildwheel
-        run: python -m pip install -U cibuildwheel==2.4.0
+        run: python -m pip install -U cibuildwheel==2.16.5
 
       - name: Build wheels
         run: python -m cibuildwheel --output-dir wheelhouse
         env:
-          CIBW_BUILD: 'cp37-* cp38-* cp39-* cp310-*'
+          CIBW_BUILD: 'cp38-* cp39-* cp310-* cp311-* cp312-*'
           CIBW_SKIP: '*-musllinux_*'
           CIBW_ARCHS: ${{ matrix.cibw_arch }}
 

--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -25,7 +25,7 @@ jobs:
       - name: Build wheels
         run: python -m cibuildwheel --output-dir wheelhouse
         env:
-          CIBW_BUILD: 'cp38-* cp39-* cp310-* cp311-* cp312-*'
+          CIBW_BUILD: 'cp38-* cp39-* cp310-* cp311-*'
           CIBW_SKIP: '*-musllinux_*'
           CIBW_ARCHS: ${{ matrix.cibw_arch }}
 


### PR DESCRIPTION
This patch enables builds for python 3.11 and 3.12.

Support for python 3.7 is droppped.