### PR TITLE
Build arm achitectures as well

### DIFF
--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        cibw_arch: ['auto64']
+        cibw_arch: ['x86_64', 'aarch64', 'arm64', 'universal2']
 
     runs-on: ${{ matrix.os }}
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.5)
 project(huffman C)
 enable_testing()
 
-set(huffman_LIBRARY_VERSION "1.0.2")
+set(huffman_LIBRARY_VERSION "1.0.3")
 set(huffman_LIBRARY_SOVERSION "1")
 
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 setup(
     name="huffmanfile",
-    version="1.0.2",
+    version="1.0.3",
 
     long_description=Path("README.md").read_text(),
     long_description_content_type="text/markdown",


### PR DESCRIPTION
This patch configures ci build to build artefacts for arm architectures.