### PR TITLE
Skip build of linux aarch64

### DIFF
--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -26,7 +26,7 @@ jobs:
         run: python -m cibuildwheel --output-dir wheelhouse
         env:
           CIBW_BUILD: 'cp38-* cp39-* cp310-* cp311-*'
-          CIBW_SKIP: '*-musllinux_*'
+          CIBW_SKIP: '*-musllinux_* *-manylinux_aarch64'
           CIBW_ARCHS: ${{ matrix.cibw_arch }}
 
       - uses: actions/upload-artifact@v2


### PR DESCRIPTION
This patch skips build o the linux aarch64.